### PR TITLE
Feature: allow multiple videos to be selected from a folder

### DIFF
--- a/EasyVideoScreensaver/App.xaml.cs
+++ b/EasyVideoScreensaver/App.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Interop;
@@ -118,9 +119,11 @@ namespace EasyVideoScreensaver
         private void LoadVideo()
         {
             media = new MediaElement();
-            if (!string.IsNullOrEmpty(settings.VideoFilename) && System.IO.File.Exists(settings.VideoFilename))
+            if (settings.VideoFilenames.Count() > 0)
             {
-                media.Source = new Uri(settings.VideoFilename, UriKind.Absolute);
+                Random random = new Random();
+                string randomVideo = settings.VideoFilenames[random.Next(0, settings.VideoFilenames.Length)];
+                media.Source = new Uri(randomVideo, UriKind.Absolute);
             }
             switch (settings.StretchMode)
             {

--- a/EasyVideoScreensaver/App.xaml.cs
+++ b/EasyVideoScreensaver/App.xaml.cs
@@ -116,15 +116,28 @@ namespace EasyVideoScreensaver
             mainWindow.Close();
         }
 
+        private string RandomVideo(string[] files)
+        {
+            Random random = new Random();
+            string randomVideo = files[random.Next(0, files.Length)];
+            while (files.Count() > 0 && !System.IO.File.Exists(randomVideo))
+            {
+                files = files.Where(f => f != randomVideo).ToArray();
+                randomVideo = files[random.Next(0, files.Length)];
+            }
+
+            // If no valid files found, screen will go black as the last video is not valid either
+            return randomVideo;
+        }
+
         private void LoadVideo()
         {
             media = new MediaElement();
             if (settings.VideoFilenames.Count() > 0)
             {
-                Random random = new Random();
-                string randomVideo = settings.VideoFilenames[random.Next(0, settings.VideoFilenames.Length)];
-                media.Source = new Uri(randomVideo, UriKind.Absolute);
+                media.Source = new Uri(RandomVideo(settings.VideoFilenames));
             }
+
             switch (settings.StretchMode)
             {
                 case "Fill":
@@ -140,6 +153,7 @@ namespace EasyVideoScreensaver
                     media.Stretch = Stretch.Uniform;
                     break;
             }
+
             media.Volume = settings.Volume;
             media.IsMuted = settings.Mute;
             if (settings.Resume)

--- a/EasyVideoScreensaver/MySettings.cs
+++ b/EasyVideoScreensaver/MySettings.cs
@@ -7,7 +7,7 @@ namespace EasyVideoScreensaver
 { 
     public class MySettings
     {
-        public string VideoFilename { get; set; }
+        public string[] VideoFilenames { get; set; }
         public string StretchMode { get; set; }
         public double Volume { get; set; }
         public Boolean Mute { get; set; }
@@ -40,7 +40,7 @@ namespace EasyVideoScreensaver
             {
                 //Get default settings
                 settings = new MySettings();
-                settings.VideoFilename = "";
+                settings.VideoFilenames = new string[] {};
                 settings.StretchMode = "Fit";
                 settings.Mute = false;
                 settings.Volume = .5;

--- a/EasyVideoScreensaver/SettingsWindow.xaml
+++ b/EasyVideoScreensaver/SettingsWindow.xaml
@@ -15,7 +15,7 @@
         <Slider Name="VolumeSlider" HorizontalAlignment="Left" Margin="113,93,0,0" VerticalAlignment="Top" Width="171" RenderTransformOrigin="0.497,0.705" Minimum="0" Maximum="1" TickFrequency="0.1" TickPlacement="BottomRight" SmallChange="0.01" ValueChanged="VolumeSlider_ValueChanged" LargeChange="0.1" Height="30"/>
         <Label Name="VolumeValueLabel"  Content="0%" HorizontalAlignment="Left" Margin="300,94,0,0" VerticalAlignment="Top" Width="98" Padding="0" Height="22" VerticalContentAlignment="Center"/>
         <CheckBox Name="MuteCheckBox" Content="Mute" HorizontalAlignment="Left" Margin="113,127,0,0" VerticalAlignment="Top" Checked="MuteCheckBox_Checked" Unchecked="MuteCheckBox_Unchecked"/>
-        <CheckBox x:Name="ResumeCheckBox" Content="Resume from previous position" HorizontalAlignment="Left" Margin="113,156,0,0" VerticalAlignment="Top"/>
+        <CheckBox x:Name="ResumeCheckBox" Content="Resume from previous position (single video only)" HorizontalAlignment="Left" Margin="113,156,0,0" VerticalAlignment="Top"/>
         <Button Name="OKButton" Content="OK" Margin="0,0,91,10.5" Height="20" VerticalAlignment="Bottom" HorizontalAlignment="Right" Width="76" IsDefault="True" Click="OKButton_Click"/>
         <Button Name="CancelButton" Content="Cancel" Margin="0,0,10,10.5" Height="20" VerticalAlignment="Bottom" HorizontalAlignment="Right" Width="76" IsCancel="True" Click="CancelButton_Click"/>
     </Grid>

--- a/EasyVideoScreensaver/SettingsWindow.xaml
+++ b/EasyVideoScreensaver/SettingsWindow.xaml
@@ -6,7 +6,7 @@
         mc:Ignorable="d"
         Title="Video Screensaver Settings" Height="260" Width="450" ResizeMode="NoResize" WindowStartupLocation="CenterScreen">
     <Grid>
-        <Label Content="Video to Play:" HorizontalAlignment="Left" Margin="10,13,0,0" VerticalAlignment="Top" Width="98" Padding="0" Height="23" VerticalContentAlignment="Center"/>
+        <Label Content="Video(s) to Play:" HorizontalAlignment="Left" Margin="10,13,0,0" VerticalAlignment="Top" Width="98" Padding="0" Height="23" VerticalContentAlignment="Center"/>
         <TextBox Name="VideoFilenameTextBox" Height="23" Margin="113,13,10,0" VerticalAlignment="Top"/>
         <Button Name="BrowseButton" Content="Browse..." Margin="113,41,0,0" VerticalAlignment="Top" Click="BrowseButton_Click" HorizontalAlignment="Left" Width="76"/>
         <Label Content="Video Size:" HorizontalAlignment="Left" Margin="10,66,0,0" VerticalAlignment="Top" Width="98" Padding="0" Height="22" VerticalContentAlignment="Center"/>

--- a/EasyVideoScreensaver/SettingsWindow.xaml.cs
+++ b/EasyVideoScreensaver/SettingsWindow.xaml.cs
@@ -1,16 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Shapes;
+
 using Microsoft.Win32;
 
 namespace EasyVideoScreensaver
@@ -34,7 +27,7 @@ namespace EasyVideoScreensaver
             StretchModeComboBox.SelectedValue = settings.StretchMode;
             VolumeSlider.Value = settings.Volume;
             MuteCheckBox.IsChecked = settings.Mute;
-            ResumeCheckBox.IsChecked = settings.Resume;
+            LoadResumeOption(settings, settings.VideoFilenames);
 
             //Set initial focus
             VideoFilenameTextBox.Focus();
@@ -74,6 +67,7 @@ namespace EasyVideoScreensaver
 
             dialog.Filter = @"Video Files|*.mp4;*.m4v;*.mp4v;*.3gp;*.3gpp;*.3g2;*.3gp2;*.mov;*.wmv;*.avi;*.mkv;*.mk3d;*.m2ts;*.m2t;*.mts;*.ts;*.tts|MP4 Video Files |*.mp4;*.m4v;*.mp4v;*.3gp;*.3gpp;*.3g2;*.3gp2|QuickTime Movie Files|*.mov|Windows Video Files|*.wmv;*.avi|MKV Video Files|*.mkv|MK3D video file|*.mk3d|MPEG-2 TS Video Files|*.m2ts;*.m2t;*.mts;*.ts;*.tts|All Files (*.*)|*.*";
             dialog.CheckFileExists = true;
+            dialog.FileOk += OnFileOk;
             if (dialog.ShowDialog() == true)
             {
                 VideoFilenameTextBox.Text = VideoFilenameText(dialog.FileNames);
@@ -107,6 +101,24 @@ namespace EasyVideoScreensaver
                 default:
                     return new System.IO.FileInfo(fileNames[0]).DirectoryName;
             }
+        }
+
+        private void LoadResumeOption(MySettings settings, string[] files)
+        {
+            if (files.Count() > 1)
+            {
+                ResumeCheckBox.IsEnabled = false;
+                ResumeCheckBox.IsChecked = false;
+            }
+            else
+            {
+                ResumeCheckBox.IsEnabled = true;
+                ResumeCheckBox.IsChecked = settings.Resume;
+            }
+        }
+        private void OnFileOk(object sender, CancelEventArgs e)
+        {
+            LoadResumeOption(settings, ((OpenFileDialog)sender).FileNames);
         }
     }
 }

--- a/EasyVideoScreensaver/SettingsWindow.xaml.cs
+++ b/EasyVideoScreensaver/SettingsWindow.xaml.cs
@@ -29,7 +29,7 @@ namespace EasyVideoScreensaver
             this.DataContext = settings;
 
             //Load settings
-            VideoFilenameTextBox.Text = settings.VideoFilename;
+            VideoFilenameTextBox.Text = VideoFilenameText(settings.VideoFilenames);
             StretchModeComboBox.ItemsSource = new List<string> { "Fit", "Fill", "Center" };
             StretchModeComboBox.SelectedValue = settings.StretchMode;
             VolumeSlider.Value = settings.Volume;
@@ -42,20 +42,7 @@ namespace EasyVideoScreensaver
 
         private void OKButton_Click(object sender, RoutedEventArgs e)
         {
-            //Validate video file exists
-            if (!string.IsNullOrEmpty(VideoFilenameTextBox.Text) && !System.IO.File.Exists(VideoFilenameTextBox.Text))
-            {
-                MessageBox.Show("The specified file does not exist.", "File Does Not Exist", MessageBoxButton.OK, MessageBoxImage.Exclamation);
-                return;
-            }
-
             //Save settings
-            if (settings.VideoFilename != VideoFilenameTextBox.Text)
-            {
-                //If video filename has changed, then reset resume position
-                settings.ResumePosition = 0;
-            }
-            settings.VideoFilename = VideoFilenameTextBox.Text;
             settings.StretchMode = (string)StretchModeComboBox.SelectedValue;
             settings.Volume = VolumeSlider.Value;
             settings.Mute = MuteCheckBox.IsChecked == true;
@@ -77,19 +64,20 @@ namespace EasyVideoScreensaver
             //Show open dialog
             OpenFileDialog dialog = new OpenFileDialog();
             dialog.Title = "Select Video File";
-            if (string.IsNullOrEmpty(settings.VideoFilename))
+            dialog.Multiselect = true;
+            if (settings.VideoFilenames.Count() == 0)
                 dialog.InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.MyVideos);
             else
             {
-                dialog.FileName = settings.VideoFilename;
-                dialog.InitialDirectory = new System.IO.FileInfo(settings.VideoFilename).DirectoryName;
+                dialog.InitialDirectory = new System.IO.FileInfo(settings.VideoFilenames[0]).DirectoryName;
             }
 
             dialog.Filter = @"Video Files|*.mp4;*.m4v;*.mp4v;*.3gp;*.3gpp;*.3g2;*.3gp2;*.mov;*.wmv;*.avi;*.mkv;*.mk3d;*.m2ts;*.m2t;*.mts;*.ts;*.tts|MP4 Video Files |*.mp4;*.m4v;*.mp4v;*.3gp;*.3gpp;*.3g2;*.3gp2|QuickTime Movie Files|*.mov|Windows Video Files|*.wmv;*.avi|MKV Video Files|*.mkv|MK3D video file|*.mk3d|MPEG-2 TS Video Files|*.m2ts;*.m2t;*.mts;*.ts;*.tts|All Files (*.*)|*.*";
             dialog.CheckFileExists = true;
             if (dialog.ShowDialog() == true)
             {
-                VideoFilenameTextBox.Text = dialog.FileName;
+                VideoFilenameTextBox.Text = VideoFilenameText(dialog.FileNames);
+                settings.VideoFilenames = dialog.FileNames;
             }
         }
 
@@ -106,6 +94,19 @@ namespace EasyVideoScreensaver
         private void MuteCheckBox_Unchecked(object sender, RoutedEventArgs e)
         {
             VolumeSlider.IsEnabled = true;
+        }
+
+        private string VideoFilenameText(string[] fileNames)
+        {
+            switch (fileNames.Count())
+            {
+                case 0:
+                    return "";
+                case 1:
+                    return fileNames[0];
+                default:
+                    return new System.IO.FileInfo(fileNames[0]).DirectoryName;
+            }
         }
     }
 }


### PR DESCRIPTION
A video will be randomly selected from the directory on screensaver start, and will loop once finished (as before) (requested in https://github.com/tonyfederer/EasyVideoScreensaver/issues/13, and https://github.com/tonyfederer/EasyVideoScreensaver/issues/4, though without the shuffle at the end of each playthrough)

![image](https://github.com/tonyfederer/EasyVideoScreensaver/assets/961597/de423217-f216-4dd8-b120-99a5ed66c8d6)
